### PR TITLE
Updated Docker port from `10000` to `10012` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ docker:
 docker-run:
 	(docker rm -f meshery-$(ADAPTER)) || true
 	docker run --name meshery-$(ADAPTER) -d \
-	-p 10000:10000 \
+	-p 10012:10012 \
 	-e DEBUG=true \
 	layer5/meshery-$(ADAPTER):$(RELEASE_CHANNEL)-latest
 


### PR DESCRIPTION
Signed-off-by: Antonette Caldwell <pullmana8@gmail.com>

**Description**

This PR fixes Makefile build step for Docker. Docker port is pointing to the same port as Meshery Adapter for Istio.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
