### PR TITLE
Run e2e tests on push 

### DIFF
--- a/.github/workflows/e2etests.yaml
+++ b/.github/workflows/e2etests.yaml
@@ -1,11 +1,16 @@
 name: (E2E Tests) Meshery Adapter for Cilium Tests
 
 on:
+  push:
+    branches:
+      - "*"
+    tags:
+      - "v*"
+    paths-ignore:
+      - 'docs/**'   
   pull_request:
     branches:
       - "*"
-    paths-ignore:
-      - '.github/**'
   release:
     types: [published]
 jobs:


### PR DESCRIPTION
Signed-off-by: Sekiranda <sekirandahamza@gmail.com>

**Description**

Meshery cilium e2e tests were only run on release and when a pull request is opened. This PR is is a fix for running e2e tests on push activity to the repo.

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
