### PR TITLE
updating adapter to v2 for all centralized e2e tests

### DIFF
--- a/.github/workflows/e2etests.yaml
+++ b/.github/workflows/e2etests.yaml
@@ -41,7 +41,7 @@ jobs:
 
   TestCilium:
     needs: SetPatternfile
-    uses: meshery/meshery/.github/workflows/test_adapters.yaml@master
+    uses: meshery/meshery/.github/workflows/test_adaptersv2.yaml@master
     with:
       expected_resources: cilium
       expected_resources_types: pod


### PR DESCRIPTION
**Description**
Migrated to v2 for meshery-cilium adapter  for all e2e tests
This PR fixes #123

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
