### PR TITLE
[chore] Update Go version to 1.25 and align GitHub Actions

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -19,9 +19,9 @@ jobs:
       with:
         fetch-depth: 1
     - name: Setup Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
-        go-version: 1.23
+        go-version: 1.25
     - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go build .
   docker:
     name: Docker build and push
@@ -32,7 +32,7 @@ jobs:
       with:
         fetch-depth: 1
     - name: Docker login
-      uses: azure/docker-login@v1
+      uses: azure/docker-login@v2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -60,7 +60,7 @@ jobs:
         docker push ${{ secrets.IMAGE_NAME }}:stable-${GITHUB_SHA::7}
     - name: Docker Hub Description
       if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/') && success()
-      uses: peter-evans/dockerhub-description@v2.0.0
+      uses: peter-evans/dockerhub-description@v5
       env:
         DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
     name: Check & Review code
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: 1.23
+          go-version: 1.25
       - uses: actions/checkout@master
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.62
@@ -40,9 +40,9 @@ jobs:
         with:
           fetch-depth: 1
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.23
+          go-version: 1.25
       - run: GOPROXY=https://proxy.golang.org,direct GOSUMDB=off GO111MODULE=on go install github.com/kisielk/errcheck@latest; /home/runner/go/bin/errcheck -tags draft ./...
   error_code_check:
     name: Error code utility check
@@ -53,9 +53,9 @@ jobs:
         with:
           fetch-depth: 1
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.23
+          go-version: 1.25
       - run: |
             errWillHave="level=error"
             GOPROXY=https://proxy.golang.org,direct GOSUMDB=off GO111MODULE=on go install github.com/layer5io/meshkit/cmd/errorutil;
@@ -75,10 +75,10 @@ jobs:
         with:
           fetch-depth: 1
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.23
-      - uses: dominikh/staticcheck-action@v1.3.0
+          go-version: 1.25
+      - uses: dominikh/staticcheck-action@v1
         with:
           version: "latest"
           install-go: false
@@ -91,9 +91,9 @@ jobs:
         with:
           fetch-depth: 1
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.23
+          go-version: 1.25
       - run: GOPROXY=https://proxy.golang.org,direct GOSUMDB=off GO111MODULE=on go vet -tags draft ./...
   sec_check:
     name: Security check
@@ -121,11 +121,11 @@ jobs:
        with:
         fetch-depth: 1
      - name: Setup Go
-       uses: actions/setup-go@v5
+       uses: actions/setup-go@v6
        with:
-        go-version: 1.23
+        go-version: 1.25
      - name: Create cluster using KinD
-       uses: engineerd/setup-kind@v0.5.0
+       uses: engineerd/setup-kind@v0
        with:
          version: "v0.11.1"
      - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.62
+          version: v2.7
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/component-generator.yml
+++ b/.github/workflows/component-generator.yml
@@ -16,9 +16,9 @@ jobs:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           ref: "master"
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.23
+          go-version: 1.25
       - name: Run adapter to create components
         run: |
           touch log.txt
@@ -33,7 +33,7 @@ jobs:
           done
           rm log.txt
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           file_pattern: templates/
           commit_user_name: l5io

--- a/.github/workflows/components-to-doc.yml
+++ b/.github/workflows/components-to-doc.yml
@@ -10,7 +10,7 @@ jobs:
   CopyComponents:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Make components to .md files
         run: |

--- a/.github/workflows/e2etests.yaml
+++ b/.github/workflows/e2etests.yaml
@@ -16,7 +16,7 @@ jobs:
       adapter_version:  ${{ env.version }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Get version of adapter
         run: |
             if [ ${{ github.event_name }} == "release" ];then
@@ -34,7 +34,7 @@ jobs:
            yq e -i '.services.cilium.version="${{ steps.glrt.outputs.release }}"' ./.github/install/deploy.yaml 
            cat ./.github/install/deploy.yaml
       - name: Uploading file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: patternfile
           path: ./.github/install/deploy.yaml 
@@ -78,7 +78,7 @@ jobs:
           repository: meshery/meshery 
           token: ${{ secrets.GH_ACCESS_TOKEN }}   
       - name: DownloadJSON
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v6
         with:
           name: data.json
       - name: echo results
@@ -111,7 +111,7 @@ jobs:
           mv test.md $filename.md
           rm data.json
       - name: Commit
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           file_pattern: docs
           commit_user_name: l5io

--- a/.github/workflows/error-ref-publisher.yml
+++ b/.github/workflows/error-ref-publisher.yml
@@ -19,9 +19,9 @@ jobs:
           ref: 'master'
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.23
+          go-version: 1.25
 
       - name: Run utility
         run: |
@@ -29,7 +29,7 @@ jobs:
           go run github.com/layer5io/meshkit/cmd/errorutil -d . update --skip-dirs meshery -i ./helpers -o ./helpers
       # to update errorutil* files in meshery-cilium repo
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_user_name: l5io
           commit_user_email: ci@meshery.io
@@ -52,7 +52,7 @@ jobs:
         run: |
           echo '{ "errors_export": "" }' | jq --slurpfile export ./helpers/errorutil_errors_export.json '.errors_export = $export[0]' > ./meshery/docs/_data/errorref/cilium_errors_export.json
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           repository: ./meshery
           commit_user_name: l5io

--- a/.github/workflows/multi-platform.yml
+++ b/.github/workflows/multi-platform.yml
@@ -73,14 +73,14 @@ jobs:
 
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       -
         name: Docker Meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ${{ secrets.IMAGE_NAME }}
           flavor: |
@@ -92,13 +92,13 @@ jobs:
             type=raw,value=${{env.RELEASE_CHANNEL}}-latest
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - 
         name: Build and Push 
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}"
           push: true
@@ -109,7 +109,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
       - 
         name: Docker Hub Description
-        uses: peter-evans/dockerhub-description@v3
+        uses: peter-evans/dockerhub-description@v5
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v6
         with:
           config-name: release-drafter.yml
         env:

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -17,7 +17,7 @@ jobs:
           echo "STARS=$(curl --silent 'https://api.github.com/repos/${{ github.repository }}' -H 'Accept: application/vnd.github.preview' | jq '.stargazers_count')" >> $GITHUB_ENV
 
       - name: Notify Slack
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@v2
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@v2
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 as build-env
+FROM golang:1.25 AS build-env
 ARG VERSION
 ARG GIT_COMMITSHA
 

--- a/build/Makefile.core.mk
+++ b/build/Makefile.core.mk
@@ -19,7 +19,7 @@ GIT_VERSION	= $(shell git describe --tags `git rev-list --tags --max-count=1`)
 GIT_COMMITSHA = $(shell git rev-list -1 HEAD)
 GIT_STRIPPED_VERSION=$(shell git describe --tags `git rev-list --tags --max-count=1` | cut -c 2-)
 
-GOVERSION = 1.23
+GOVERSION = 1.25
 GOPATH = $(shell go env GOPATH)
 GOBIN  = $(GOPATH)/bin
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/layer5io/meshery-cilium
 
-go 1.23
+go 1.25
 
 replace github.com/kudobuilder/kuttl => github.com/layer5io/kuttl v0.4.1-0.20200723152044-916f10574334
 


### PR DESCRIPTION
**Description**

This PR fixes #188 

**Changes made :**

- Updates the Go version used in this repository from 1.24 to 1.25.

- Updates GitHub Action version tags across the workflows to their latest stable releases.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

