### PR TITLE
ci: specify master branch for meshery checkout in e2etests

### DIFF
--- a/.github/workflows/e2etests.yaml
+++ b/.github/workflows/e2etests.yaml
@@ -77,6 +77,7 @@ jobs:
         with:
           repository: meshery/meshery 
           token: ${{ secrets.GH_ACCESS_TOKEN }}   
+          ref: master
       - name: DownloadJSON
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/e2etests.yaml
+++ b/.github/workflows/e2etests.yaml
@@ -16,7 +16,7 @@ jobs:
       adapter_version:  ${{ env.version }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Get version of adapter
         run: |
             if [ ${{ github.event_name }} == "release" ];then
@@ -34,7 +34,7 @@ jobs:
            yq e -i '.services.cilium.version="${{ steps.glrt.outputs.release }}"' ./.github/install/deploy.yaml 
            cat ./.github/install/deploy.yaml
       - name: Uploading file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v8
         with:
           name: patternfile
           path: ./.github/install/deploy.yaml 
@@ -73,13 +73,13 @@ jobs:
             if [ "${{github.event_name }}" == "release" ];then
               echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
             fi
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v6
         with:
           repository: meshery/meshery 
           token: ${{ secrets.GH_ACCESS_TOKEN }}   
           ref: master
       - name: DownloadJSON
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v8
         with:
           name: data.json
       - name: echo results


### PR DESCRIPTION
Description
This PR addresses the issue where the e2etests workflow was checking out the meshery/meshery repository in a "detached HEAD" state. By explicitly specifying ref: master, we ensure that the subsequent steps have the correct branch context to perform a push.
​Changes
​Updated actions/checkout to v6 for all checkout steps to ensure version consistency and security.
​Updated actions/upload-artifact to v8.
​Updated actions/download-artifact to v8.
​Added ref: master to the meshery/meshery checkout to resolve the detached HEAD failure.
​Fixes
Fixes #190