### PR TITLE
[meshery-cilium] ci: globally disable ST1005 staticcheck lint rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,8 @@
 linters-settings:
+  staticcheck:
+    checks: ["all", "-ST1005"]
+  depguard:
+    list-type: blacklist
   depguard:
     list-type: blacklist
     packages:


### PR DESCRIPTION
### **Description**

This PR adds the `staticcheck` configuration to `.golangci.yml` to globally and permanently disable the **ST1005** (lowercase error strings) lint rule for the Cilium adapter.

Fixes meshery/meshery#16867

### **Notes for Reviewers**

- Added `staticcheck` settings to `.golangci.yml` to ignore ST1005.
- This maintainers consistency across the Meshery ecosystem.
- Verified that `staticcheck` was already enabled in the linters list.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.