### PR TITLE
chore: bump Go version to 1.26.4

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23
+        go-version-file: go.mod
     - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go build .
   docker:
     name: Docker build and push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version-file: go.mod
       - uses: actions/checkout@master
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version-file: go.mod
       - run: GOPROXY=https://proxy.golang.org,direct GOSUMDB=off GO111MODULE=on go install github.com/kisielk/errcheck@latest; /home/runner/go/bin/errcheck -tags draft ./...
   error_code_check:
     name: Error code utility check
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version-file: go.mod
       - run: |
             errWillHave="level=error"
             GOPROXY=https://proxy.golang.org,direct GOSUMDB=off GO111MODULE=on go install github.com/layer5io/meshkit/cmd/errorutil;
@@ -77,7 +77,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version-file: go.mod
       - uses: dominikh/staticcheck-action@v1.3.0
         with:
           version: "latest"
@@ -93,7 +93,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version-file: go.mod
       - run: GOPROXY=https://proxy.golang.org,direct GOSUMDB=off GO111MODULE=on go vet -tags draft ./...
   sec_check:
     name: Security check
@@ -123,7 +123,7 @@ jobs:
      - name: Setup Go
        uses: actions/setup-go@v5
        with:
-        go-version: 1.23
+        go-version-file: go.mod
      - name: Create cluster using KinD
        uses: engineerd/setup-kind@v0.5.0
        with:

--- a/.github/workflows/component-generator.yml
+++ b/.github/workflows/component-generator.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version-file: go.mod
       - name: Run adapter to create components
         run: |
           touch log.txt

--- a/.github/workflows/error-ref-publisher.yml
+++ b/.github/workflows/error-ref-publisher.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version-file: go.mod
 
       - name: Run utility
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 as build-env
+FROM golang:1.26.4 as build-env
 ARG VERSION
 ARG GIT_COMMITSHA
 

--- a/build/Makefile.core.mk
+++ b/build/Makefile.core.mk
@@ -19,7 +19,7 @@ GIT_VERSION	= $(shell git describe --tags `git rev-list --tags --max-count=1`)
 GIT_COMMITSHA = $(shell git rev-list -1 HEAD)
 GIT_STRIPPED_VERSION=$(shell git describe --tags `git rev-list --tags --max-count=1` | cut -c 2-)
 
-GOVERSION = 1.23
+GOVERSION = 1.26.4
 GOPATH = $(shell go env GOPATH)
 GOBIN  = $(GOPATH)/bin
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/layer5io/meshery-cilium
 
-go 1.23
+go 1.26.4
 
 replace github.com/kudobuilder/kuttl => github.com/layer5io/kuttl v0.4.1-0.20200723152044-916f10574334
 


### PR DESCRIPTION
**Description**

Upgrade Go version from 1.25 to 1.26.4.

**Fixes:** meshery/meshery#19875

**Verified with:**

- `go build ./...`
- `go test ./...`
- `go vet ./...`

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 